### PR TITLE
Add name and avatar to account

### DIFF
--- a/app/data/account_store.go
+++ b/app/data/account_store.go
@@ -12,7 +12,12 @@ import (
 )
 
 type AccountStore interface {
-	Create(u string, p []byte) (*models.Account, error)
+	Create(user struct {
+		Username   string
+		Password   []byte
+		Name       string
+		PictureURL string
+	}) (*models.Account, error)
 	Find(id int) (*models.Account, error)
 	FindByUsername(u string) (*models.Account, error)
 	FindByOauthAccount(p string, pid string) (*models.Account, error)
@@ -30,11 +35,14 @@ type AccountStore interface {
 func NewAccountStore(db sqlx.Ext) (AccountStore, error) {
 	switch db.DriverName() {
 	case "sqlite3":
-		return &sqlite3.AccountStore{Ext: db}, nil
+		store := sqlite3.New(db)
+		return &store, nil
 	case "mysql":
-		return &mysql.AccountStore{Ext: db}, nil
+		store := mysql.New(db)
+		return &store, nil
 	case "postgres":
-		return &postgres.AccountStore{Ext: db}, nil
+		store := postgres.New(db)
+		return &store, nil
 	default:
 		return nil, fmt.Errorf("unsupported driver: %v", db.DriverName())
 	}

--- a/app/data/mock/account_store.go
+++ b/app/data/mock/account_store.go
@@ -59,16 +59,18 @@ func (s *accountStore) FindByOauthAccount(provider string, providerID string) (*
 	return dupAccount(*s.accountsByID[id]), nil
 }
 
-func (s *accountStore) Create(u string, p []byte) (*models.Account, error) {
-	if s.idByUsername[u] != 0 {
+func (s *accountStore) Create(user struct {Username string; Password []byte; Name string; PictureURL string}) (*models.Account, error) {
+	if s.idByUsername[user.Username] != 0 {
 		return nil, Error{ErrNotUnique}
 	}
 
 	now := time.Now()
 	acc := models.Account{
 		ID:                len(s.accountsByID) + 1,
-		Username:          u,
-		Password:          p,
+		Username:          user.Username,
+		Password:          user.Password,
+		Name:              user.Name,
+		Picture:           user.PictureURL,
 		PasswordChangedAt: now,
 		CreatedAt:         now,
 		UpdatedAt:         now,

--- a/app/data/mysql/account_store.go
+++ b/app/data/mysql/account_store.go
@@ -8,11 +8,15 @@ import (
 	"github.com/keratin/authn-server/app/models"
 )
 
-type AccountStore struct {
+func New(db sqlx.Ext) accountStore {
+	return accountStore{db}
+}
+
+type accountStore struct {
 	sqlx.Ext
 }
 
-func (db *AccountStore) Find(id int) (*models.Account, error) {
+func (db *accountStore) Find(id int) (*models.Account, error) {
 	account := models.Account{}
 	err := sqlx.Get(db, &account, "SELECT * FROM accounts WHERE id = ?", id)
 	if err == sql.ErrNoRows {
@@ -22,11 +26,13 @@ func (db *AccountStore) Find(id int) (*models.Account, error) {
 	}
 	if account.DeletedAt != nil {
 		account.Username = ""
+		account.Picture = ""
+		account.Name = ""
 	}
 	return &account, nil
 }
 
-func (db *AccountStore) FindByUsername(u string) (*models.Account, error) {
+func (db *accountStore) FindByUsername(u string) (*models.Account, error) {
 	account := models.Account{}
 	err := sqlx.Get(db, &account, "SELECT * FROM accounts WHERE username = ? AND deleted_at IS NULL", u)
 	if err == sql.ErrNoRows {
@@ -37,7 +43,7 @@ func (db *AccountStore) FindByUsername(u string) (*models.Account, error) {
 	return &account, nil
 }
 
-func (db *AccountStore) FindByOauthAccount(provider string, providerID string) (*models.Account, error) {
+func (db *accountStore) FindByOauthAccount(provider string, providerID string) (*models.Account, error) {
 	account := models.Account{}
 	err := sqlx.Get(db, &account, "SELECT a.* FROM accounts a INNER JOIN oauth_accounts oa ON a.id = oa.account_id WHERE oa.provider = ? AND oa.provider_id = ?", provider, providerID)
 	if err == sql.ErrNoRows {
@@ -48,19 +54,26 @@ func (db *AccountStore) FindByOauthAccount(provider string, providerID string) (
 	return &account, nil
 }
 
-func (db *AccountStore) Create(u string, p []byte) (*models.Account, error) {
+func (db *accountStore) Create(user struct {
+	Username   string
+	Password   []byte
+	Name       string
+	PictureURL string
+}) (*models.Account, error) {
 	now := time.Now()
 
 	account := &models.Account{
-		Username:          u,
-		Password:          p,
+		Username:          user.Username,
+		Password:          user.Password,
+		Name:              user.Name,
+		Picture:           user.PictureURL,
 		PasswordChangedAt: now,
 		CreatedAt:         now,
 		UpdatedAt:         now,
 	}
 
 	result, err := sqlx.NamedExec(db,
-		"INSERT INTO accounts (username, password, locked, require_new_password, password_changed_at, created_at, updated_at) VALUES (:username, :password, :locked, :require_new_password, :password_changed_at, :created_at, :updated_at)",
+		"INSERT INTO accounts (username, password, name, picture, locked, require_new_password, password_changed_at, created_at, updated_at) VALUES (:username, :password, :name, :picture, :locked, :require_new_password, :password_changed_at, :created_at, :updated_at)",
 		account,
 	)
 	if err != nil {
@@ -76,7 +89,7 @@ func (db *AccountStore) Create(u string, p []byte) (*models.Account, error) {
 	return account, nil
 }
 
-func (db *AccountStore) AddOauthAccount(accountID int, provider string, providerID string, accessToken string) error {
+func (db *accountStore) AddOauthAccount(accountID int, provider string, providerID string, accessToken string) error {
 	now := time.Now()
 
 	_, err := sqlx.NamedExec(db, `
@@ -93,13 +106,13 @@ func (db *AccountStore) AddOauthAccount(accountID int, provider string, provider
 	return err
 }
 
-func (db *AccountStore) GetOauthAccounts(accountID int) ([]*models.OauthAccount, error) {
+func (db *accountStore) GetOauthAccounts(accountID int) ([]*models.OauthAccount, error) {
 	accounts := []*models.OauthAccount{}
 	err := sqlx.Select(db, &accounts, `SELECT * FROM oauth_accounts WHERE account_id = ?`, accountID)
 	return accounts, err
 }
 
-func (db *AccountStore) Archive(id int) (bool, error) {
+func (db *accountStore) Archive(id int) (bool, error) {
 	_, err := db.Exec("DELETE FROM oauth_accounts WHERE account_id = ?", id)
 	if err != nil {
 		return false, err
@@ -108,32 +121,32 @@ func (db *AccountStore) Archive(id int) (bool, error) {
 	return ok(result, err)
 }
 
-func (db *AccountStore) Lock(id int) (bool, error) {
+func (db *accountStore) Lock(id int) (bool, error) {
 	result, err := db.Exec("UPDATE accounts SET locked = ?, updated_at = ? WHERE id = ?", true, time.Now(), id)
 	return ok(result, err)
 }
 
-func (db *AccountStore) Unlock(id int) (bool, error) {
+func (db *accountStore) Unlock(id int) (bool, error) {
 	result, err := db.Exec("UPDATE accounts SET locked = ?, updated_at = ? WHERE id = ?", false, time.Now(), id)
 	return ok(result, err)
 }
 
-func (db *AccountStore) RequireNewPassword(id int) (bool, error) {
+func (db *accountStore) RequireNewPassword(id int) (bool, error) {
 	result, err := db.Exec("UPDATE accounts SET require_new_password = ?, updated_at = ? WHERE id = ?", true, time.Now(), id)
 	return ok(result, err)
 }
 
-func (db *AccountStore) SetPassword(id int, p []byte) (bool, error) {
+func (db *accountStore) SetPassword(id int, p []byte) (bool, error) {
 	result, err := db.Exec("UPDATE accounts SET password = ?, require_new_password = ?, password_changed_at = ?, updated_at = ? WHERE id = ?", p, false, time.Now(), time.Now(), id)
 	return ok(result, err)
 }
 
-func (db *AccountStore) UpdateUsername(id int, u string) (bool, error) {
+func (db *accountStore) UpdateUsername(id int, u string) (bool, error) {
 	result, err := db.Exec("UPDATE accounts SET username = ?, updated_at = ? WHERE id = ?", u, time.Now(), id)
 	return ok(result, err)
 }
 
-func (db *AccountStore) SetLastLogin(id int) (bool, error) {
+func (db *accountStore) SetLastLogin(id int) (bool, error) {
 	result, err := db.Exec("UPDATE accounts SET last_login_at = ? WHERE id = ?", time.Now(), id)
 	return ok(result, err)
 }

--- a/app/data/mysql/account_store_test.go
+++ b/app/data/mysql/account_store_test.go
@@ -11,10 +11,10 @@ import (
 func TestAccountStore(t *testing.T) {
 	db, err := mysql.TestDB()
 	require.NoError(t, err)
-	store := &mysql.AccountStore{db}
+	store := mysql.New(db)
 	for _, tester := range testers.AccountStoreTesters {
 		db.MustExec("TRUNCATE accounts")
 		db.MustExec("TRUNCATE oauth_accounts")
-		tester(t, store)
+		tester(t, &store)
 	}
 }

--- a/app/data/mysql/migrations.go
+++ b/app/data/mysql/migrations.go
@@ -12,6 +12,7 @@ func MigrateDB(db *sqlx.DB) error {
 		createAccounts,
 		createOauthAccounts,
 		createAccountLastLoginAtField,
+		addNameAndAvatarFields,
 	}
 	for _, m := range migrations {
 		if err := m(db); err != nil {
@@ -60,7 +61,21 @@ func createOauthAccounts(db *sqlx.DB) error {
 
 func createAccountLastLoginAtField(db *sqlx.DB) error {
 	_, err := db.Exec(`
-        ALTER TABLE accounts ADD last_login_at DATETIME DEFAULT NULL
+        ALTER TABLE accounts ADD last_login_at DATETIME DEFAULT NULL;
+    `)
+	if mysqlError, ok := err.(*mysql.MySQLError); ok {
+		if mysqlError.Number == 1060 { // 1060 = Duplicate column name
+			err = nil
+		}
+	}
+	return err
+}
+
+func addNameAndAvatarFields(db *sqlx.DB) error {
+	_, err := db.Exec(`
+        ALTER TABLE accounts 
+            ADD name VARCHAR(255) DEFAULT NULL,
+			ADD picture VARCHAR(512) DEFAULT NULL;
     `)
 	if mysqlError, ok := err.(*mysql.MySQLError); ok {
 		if mysqlError.Number == 1060 { // 1060 = Duplicate column name

--- a/app/data/postgres/account_store_test.go
+++ b/app/data/postgres/account_store_test.go
@@ -38,10 +38,10 @@ func newTestDB() (*sqlx.DB, error) {
 func TestAccountStore(t *testing.T) {
 	db, err := newTestDB()
 	require.NoError(t, err)
-	store := &postgres.AccountStore{db}
+	store := postgres.New(db)
 	for _, tester := range testers.AccountStoreTesters {
 		db.MustExec("TRUNCATE accounts")
 		db.MustExec("TRUNCATE oauth_accounts")
-		tester(t, store)
+		tester(t, &store)
 	}
 }

--- a/app/data/postgres/migrations.go
+++ b/app/data/postgres/migrations.go
@@ -11,6 +11,7 @@ func MigrateDB(db *sqlx.DB) error {
 		migrateAccounts,
 		createOauthAccounts,
 		createAccountLastLoginAtField,
+		createAccountNamePictureFields,
 	}
 	for _, m := range migrations {
 		if err := m(db); err != nil {
@@ -56,6 +57,14 @@ func createOauthAccounts(db *sqlx.DB) error {
 func createAccountLastLoginAtField(db *sqlx.DB) error {
 	_, err := db.Exec(`
         ALTER TABLE accounts ADD COLUMN IF NOT EXISTS last_login_at timestamptz DEFAULT NULL
+    `)
+	return err
+}
+
+func createAccountNamePictureFields(db *sqlx.DB) error {
+	_, err := db.Exec(`
+        ALTER TABLE accounts ADD COLUMN IF NOT EXISTS name VARCHAR(255) DEFAULT NULL;
+        ALTER TABLE accounts ADD COLUMN IF NOT EXISTS picture VARCHAR(512) DEFAULT NULL;
     `)
 	return err
 }

--- a/app/data/sqlite3/account_store_test.go
+++ b/app/data/sqlite3/account_store_test.go
@@ -12,8 +12,8 @@ func TestAccountStore(t *testing.T) {
 	for _, tester := range testers.AccountStoreTesters {
 		db, err := sqlite3.TestDB()
 		require.NoError(t, err)
-		store := &sqlite3.AccountStore{db}
-		tester(t, store)
+		store := sqlite3.New(db)
+		tester(t, &store)
 		db.Close()
 	}
 }

--- a/app/data/sqlite3/migrations.go
+++ b/app/data/sqlite3/migrations.go
@@ -13,6 +13,7 @@ func MigrateDB(db *sqlx.DB) error {
 		createBlobs,
 		createOauthAccounts,
 		createAccountLastLoginAtField,
+		createAccountNamePictureFields,
 	}
 	for _, m := range migrations {
 		if err := m(db); err != nil {
@@ -87,6 +88,14 @@ func createOauthAccounts(db *sqlx.DB) error {
 func createAccountLastLoginAtField(db *sqlx.DB) error {
 	_, err := db.Exec(`
         ALTER TABLE accounts ADD last_login_at DATETIME
+    `)
+	return err
+}
+
+func createAccountNamePictureFields(db *sqlx.DB) error {
+	_, err := db.Exec(`
+        ALTER TABLE accounts ADD name TEXT;
+        ALTER TABLE accounts ADD picture TEXT;
     `)
 	return err
 }

--- a/app/data/testers/account_store_testers.go
+++ b/app/data/testers/account_store_testers.go
@@ -37,15 +37,17 @@ func getOpenConnectionCount(store data.AccountStore) int {
 }
 
 func testCreate(t *testing.T, store data.AccountStore) {
-	account, err := store.Create("authn@keratin.tech", []byte("password"))
+	account, err := store.Create(User{Username: "authn@keratin.tech", Password: []byte("password"), Name: "Keratin Auth", PictureURL: "http://apic.com/pic12312321.png"})
 	require.NoError(t, err)
 	assert.NotEqual(t, 0, account.ID)
 	assert.Equal(t, "authn@keratin.tech", account.Username)
 	assert.NotEmpty(t, account.PasswordChangedAt)
+	assert.Equal(t,  "Keratin Auth", account.Name)
+	assert.Equal(t,  "http://apic.com/pic12312321.png", account.Picture)
 	assert.NotEmpty(t, account.CreatedAt)
 	assert.NotEmpty(t, account.UpdatedAt)
 
-	account, err = store.Create("authn@keratin.tech", []byte("password"))
+	account, err = store.Create(User{Username: "authn@keratin.tech", Password: []byte("password")})
 	if account != nil {
 		assert.NotEqual(t, nil, account)
 	}
@@ -62,7 +64,7 @@ func testFindByUsername(t *testing.T, store data.AccountStore) {
 	assert.NoError(t, err)
 	assert.Nil(t, account)
 
-	_, err = store.Create("authn@keratin.tech", []byte("password"))
+	_, err = store.Create(User{Username: "authn@keratin.tech", Password: []byte("password")})
 	require.NoError(t, err)
 
 	account, err = store.FindByUsername("authn@keratin.tech")
@@ -74,7 +76,7 @@ func testFindByUsername(t *testing.T, store data.AccountStore) {
 }
 
 func testLockAndUnlock(t *testing.T, store data.AccountStore) {
-	account, err := store.Create("authn@keratin.tech", []byte("password"))
+	account, err := store.Create(User{Username: "authn@keratin.tech", Password: []byte("password")})
 	require.NoError(t, err)
 	require.False(t, account.Locked)
 
@@ -100,7 +102,7 @@ func testLockAndUnlock(t *testing.T, store data.AccountStore) {
 }
 
 func testArchive(t *testing.T, store data.AccountStore) {
-	account, err := store.Create("authn@keratin.tech", []byte("password"))
+	account, err := store.Create(User{Username: "authn@keratin.tech", Password: []byte("password")})
 	require.NoError(t, err)
 	require.Empty(t, account.DeletedAt)
 
@@ -115,7 +117,7 @@ func testArchive(t *testing.T, store data.AccountStore) {
 	assert.Empty(t, after.Password)
 	assert.NotEmpty(t, after.DeletedAt)
 
-	account2, err := store.Create("authn@keratin.tech", []byte("password"))
+	account2, err := store.Create(User{Username: "authn@keratin.tech", Password: []byte("password")})
 	if assert.NoError(t, err) {
 		ok, err = store.Archive(account2.ID)
 		assert.True(t, ok)
@@ -127,7 +129,7 @@ func testArchive(t *testing.T, store data.AccountStore) {
 }
 
 func testArchiveWithOauth(t *testing.T, store data.AccountStore) {
-	account, err := store.Create("authn@keratin.tech", []byte("password"))
+	account, err := store.Create(User{Username: "authn@keratin.tech", Password: []byte("password")})
 	require.NoError(t, err)
 	err = store.AddOauthAccount(account.ID, "PROVIDER", "PROVIDERID", "token")
 	require.NoError(t, err)
@@ -145,7 +147,7 @@ func testArchiveWithOauth(t *testing.T, store data.AccountStore) {
 }
 
 func testRequireNewPassword(t *testing.T, store data.AccountStore) {
-	account, err := store.Create("authn@keratin.tech", []byte("password"))
+	account, err := store.Create(User{Username: "authn@keratin.tech", Password: []byte("password")})
 	require.NoError(t, err)
 	require.False(t, account.RequireNewPassword)
 
@@ -162,7 +164,7 @@ func testRequireNewPassword(t *testing.T, store data.AccountStore) {
 }
 
 func testSetPassword(t *testing.T, store data.AccountStore) {
-	account, err := store.Create("authn@keratin.tech", []byte("old"))
+	account, err := store.Create(User{Username: "authn@keratin.tech", Password: []byte("old")})
 	require.NoError(t, err)
 	ok, err := store.RequireNewPassword(account.ID)
 	require.True(t, ok)
@@ -183,10 +185,10 @@ func testSetPassword(t *testing.T, store data.AccountStore) {
 }
 
 func testUpdateUsername(t *testing.T, store data.AccountStore) {
-	other, err := store.Create("other", []byte("other"))
+	other, err := store.Create(User{Username: "other", Password: []byte("other")})
 	require.NoError(t, err)
 
-	account, err := store.Create("old", []byte("old"))
+	account, err := store.Create(User{Username: "old", Password: []byte("old")})
 	require.NoError(t, err)
 
 	ok, err := store.UpdateUsername(account.ID, "new")
@@ -216,7 +218,7 @@ func testAddOauthAccount(t *testing.T, store data.AccountStore) {
 	require.NoError(t, err)
 	assert.Len(t, found, 0)
 
-	account, err := store.Create("authn@keratin.tech", []byte("password"))
+	account, err := store.Create(User{Username: "authn@keratin.tech", Password: []byte("password")})
 	assert.NoError(t, err)
 	err = store.AddOauthAccount(account.ID, "OAUTHPROVIDER", "PROVIDERID", "TOKEN")
 	assert.NoError(t, err)
@@ -245,7 +247,7 @@ func testFindByOauthAccount(t *testing.T, store data.AccountStore) {
 	assert.NoError(t, err)
 	assert.Nil(t, found)
 
-	account, err := store.Create("authn@keratin.tech", []byte("password"))
+	account, err := store.Create(User{Username: "authn@keratin.tech", Password: []byte("password")})
 	require.NoError(t, err)
 	err = store.AddOauthAccount(account.ID, "OAUTHPROVIDER", "PROVIDERID", "TOKEN")
 	require.NoError(t, err)
@@ -267,7 +269,7 @@ func testFindByOauthAccount(t *testing.T, store data.AccountStore) {
 }
 
 func testSetLastLogin(t *testing.T, store data.AccountStore) {
-	account, err := store.Create("old", []byte("old"))
+	account, err := store.Create(User{Username: "old", Password: []byte("old")})
 	require.NoError(t, err)
 
 	rowsIsAffected, err := store.SetLastLogin(account.ID)

--- a/app/data/testers/models.go
+++ b/app/data/testers/models.go
@@ -1,0 +1,8 @@
+package testers
+
+type User struct {
+	Username   string // must be set
+	Password   []byte
+	Name       string
+	PictureURL string
+}

--- a/app/models/account.go
+++ b/app/models/account.go
@@ -1,10 +1,14 @@
 package models
 
-import "time"
+import (
+	"time"
+)
 
 type Account struct {
 	ID                 int
 	Username           string
+	Name               string
+	Picture            string
 	Password           []byte
 	Locked             bool
 	RequireNewPassword bool       `db:"require_new_password"`

--- a/app/services/account_archiver_test.go
+++ b/app/services/account_archiver_test.go
@@ -14,7 +14,7 @@ func TestAccountArchiver(t *testing.T) {
 	refreshStore := mock.NewRefreshTokenStore()
 
 	t.Run("existing account", func(t *testing.T) {
-		account, err := accountStore.Create("test@keratin.tech", []byte("password"))
+		account, err := accountStore.Create(services.User{Username: "test@keratin.tech", Password: []byte("password")})
 		require.NoError(t, err)
 
 		errs := services.AccountArchiver(accountStore, refreshStore, account.ID)
@@ -28,7 +28,7 @@ func TestAccountArchiver(t *testing.T) {
 	})
 
 	t.Run("logged in account", func(t *testing.T) {
-		account, err := accountStore.Create("loggedin@keratin.tech", []byte("password"))
+		account, err := accountStore.Create(services.User{Username: "loggedin@keratin.tech", Password: []byte("password")})
 		require.NoError(t, err)
 		token1, err := refreshStore.Create(account.ID)
 		require.NoError(t, err)

--- a/app/services/account_creator.go
+++ b/app/services/account_creator.go
@@ -10,8 +10,8 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
-func AccountCreator(store data.AccountStore, cfg *app.Config, username string, password string) (*models.Account, error) {
-	username = strings.TrimSpace(username)
+func AccountCreator(store data.AccountStore, cfg *app.Config, user User) (*models.Account, error) {
+	username := strings.TrimSpace(user.Username)
 
 	errs := FieldErrors{}
 
@@ -20,7 +20,7 @@ func AccountCreator(store data.AccountStore, cfg *app.Config, username string, p
 		errs = append(errs, *fieldError)
 	}
 
-	fieldError = PasswordValidator(cfg, password)
+	fieldError = PasswordValidator(cfg, string(user.Password))
 	if fieldError != nil {
 		errs = append(errs, *fieldError)
 	}
@@ -29,12 +29,12 @@ func AccountCreator(store data.AccountStore, cfg *app.Config, username string, p
 		return nil, errs
 	}
 
-	hash, err := bcrypt.GenerateFromPassword([]byte(password), cfg.BcryptCost)
+	hash, err := bcrypt.GenerateFromPassword(user.Password, cfg.BcryptCost)
 	if err != nil {
 		return nil, errors.Wrap(err, "bcrypt")
 	}
 
-	acc, err := store.Create(username, hash)
+	acc, err := store.Create(User{Username: username, Password: hash, Name: user.Name, PictureURL: user.PictureURL})
 
 	if err != nil {
 		if data.IsUniquenessError(err) {

--- a/app/services/account_importer.go
+++ b/app/services/account_importer.go
@@ -13,26 +13,28 @@ import (
 
 var bcryptPattern = regexp.MustCompile(`\A\$2[ayb]\$[0-9]{2}\$[A-Za-z0-9\.\/]{53}\z`)
 
-func AccountImporter(store data.AccountStore, cfg *app.Config, username string, password string, locked bool) (*models.Account, error) {
-	if username == "" {
+func AccountImporter(store data.AccountStore, cfg *app.Config, user User, locked bool) (*models.Account, error) {
+	if user.Username == "" {
 		return nil, FieldErrors{{"username", ErrMissing}}
 	}
-	if password == "" {
+	if string(user.Password) == "" {
 		return nil, FieldErrors{{"password", ErrMissing}}
 	}
 
 	var hash []byte
 	var err error
-	if bcryptPattern.Match([]byte(password)) {
-		hash = []byte(password)
+	if bcryptPattern.Match(user.Password) {
+		hash = user.Password
 	} else {
-		hash, err = bcrypt.GenerateFromPassword([]byte(password), cfg.BcryptCost)
+		hash, err = bcrypt.GenerateFromPassword(user.Password, cfg.BcryptCost)
 		if err != nil {
 			return nil, errors.Wrap(err, "bcrypt")
 		}
 	}
 
-	acc, err := store.Create(username, hash)
+	newUser := user
+	newUser.Password = hash
+	acc, err := store.Create(newUser)
 	if err != nil {
 		if data.IsUniquenessError(err) {
 			return nil, FieldErrors{{"username", ErrTaken}}

--- a/app/services/account_importer_test.go
+++ b/app/services/account_importer_test.go
@@ -21,30 +21,35 @@ func TestAccountImporter(t *testing.T) {
 		BcryptCost: 4,
 	}
 
-	_, err := accountStore.Create("existing", []byte("secret"))
+	_, err := accountStore.Create(services.User{Username: "existing", Password: []byte("secret"), Name: "A Name", PictureURL: "aPicURL"})
 	require.NoError(t, err)
 
 	testCases := []struct {
 		username string
 		password []byte
+		name     string
+		pic      string
 		locked   bool
 		errors   *services.FieldErrors
 	}{
-		{"unlocked", bcrypted, false, nil},
-		{"locked", bcrypted, true, nil},
-		{"plaintext", []byte("secret"), false, nil},
-		{"", bcrypted, false, &services.FieldErrors{{"username", services.ErrMissing}}},
-		{"invalid", []byte(""), false, &services.FieldErrors{{"password", services.ErrMissing}}},
-		{"existing", bcrypted, false, &services.FieldErrors{{"username", services.ErrTaken}}},
+		{"unlocked", bcrypted, "", "", false, nil},
+		{"with_name", bcrypted, "Someone van Surname", "http://not.valid/asdasd.png", false, nil},
+		{"locked", bcrypted, "", "", true, nil},
+		{"plaintext", []byte("secret"), "", "", false, nil},
+		{"", bcrypted, "", "", false, &services.FieldErrors{{"username", services.ErrMissing}}},
+		{"invalid", []byte(""), "", "", false, &services.FieldErrors{{"password", services.ErrMissing}}},
+		{"existing", bcrypted, "", "", false, &services.FieldErrors{{"username", services.ErrTaken}}},
 	}
 
 	for _, tc := range testCases {
-		account, errors := services.AccountImporter(accountStore, cfg, tc.username, string(tc.password), tc.locked)
+		account, errors := services.AccountImporter(accountStore, cfg, services.User{Username: tc.username, Password: tc.password, Name: tc.name, PictureURL: tc.pic}, tc.locked)
 		if tc.errors == nil {
 			assert.Empty(t, errors)
 			assert.NotEmpty(t, account)
 			assert.Equal(t, tc.locked, account.Locked)
 			assert.Equal(t, tc.username, account.Username)
+			assert.Equal(t, tc.name, account.Name)
+			assert.Equal(t, tc.pic, account.Picture)
 			assert.NoError(t, bcrypt.CompareHashAndPassword(account.Password, []byte("secret")))
 		} else {
 			assert.Equal(t, *tc.errors, errors)

--- a/app/services/account_locker_test.go
+++ b/app/services/account_locker_test.go
@@ -14,7 +14,7 @@ func TestAccountLocker(t *testing.T) {
 	refreshStore := mock.NewRefreshTokenStore()
 
 	t.Run("logged in account", func(t *testing.T) {
-		account, err := accountStore.Create("loggedin@keratin.tech", []byte("password"))
+		account, err := accountStore.Create(services.User{Username: "loggedin@keratin.tech", Password: []byte("password")})
 		require.NoError(t, err)
 		token1, err := refreshStore.Create(account.ID)
 		require.NoError(t, err)
@@ -28,7 +28,7 @@ func TestAccountLocker(t *testing.T) {
 	})
 
 	t.Run("locked account", func(t *testing.T) {
-		account, err := accountStore.Create("locked@keratin.tech", []byte("password"))
+		account, err := accountStore.Create(services.User{Username: "locked@keratin.tech", Password: []byte("password")})
 		require.NoError(t, err)
 		_, err = accountStore.Lock(account.ID)
 		require.NoError(t, err)
@@ -42,7 +42,7 @@ func TestAccountLocker(t *testing.T) {
 	})
 
 	t.Run("unlocked account", func(t *testing.T) {
-		account, err := accountStore.Create("unlocked@keratin.tech", []byte("password"))
+		account, err := accountStore.Create(services.User{Username: "unlocked@keratin.tech", Password: []byte("password")})
 		require.NoError(t, err)
 
 		errs := services.AccountLocker(accountStore, refreshStore, account.ID)

--- a/app/services/account_unlocker_test.go
+++ b/app/services/account_unlocker_test.go
@@ -12,12 +12,12 @@ import (
 func TestAccountUnlocker(t *testing.T) {
 	store := mock.NewAccountStore()
 
-	lockedAccount, err := store.Create("locked@keratin.tech", []byte("password"))
+	lockedAccount, err := store.Create(services.User{Username: "locked@keratin.tech", Password: []byte("password")})
 	require.NoError(t, err)
 	_, err = store.Lock(lockedAccount.ID)
 	require.NoError(t, err)
 
-	unlockedAccount, err := store.Create("unlocked@keratin.tech", []byte("password"))
+	unlockedAccount, err := store.Create(services.User{Username: "unlocked@keratin.tech", Password: []byte("password")})
 	require.NoError(t, err)
 
 	var testCases = []struct {

--- a/app/services/account_updater_test.go
+++ b/app/services/account_updater_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestAccountUpdater(t *testing.T) {
 	accountStore := mock.NewAccountStore()
-	existing, err := accountStore.Create("existing", []byte("secret"))
+	existing, err := accountStore.Create(services.User{Username: "existing", Password: []byte("secret")})
 	require.NoError(t, err)
 
 	t.Run("email usernames", func(t *testing.T) {
@@ -43,7 +43,7 @@ func TestAccountUpdater(t *testing.T) {
 			UsernameMinLength: 3,
 		}
 
-		other, err := accountStore.Create("other", []byte("secret"))
+		other, err := accountStore.Create(services.User{Username: "other", Password: []byte("secret")})
 		require.NoError(t, err)
 
 		err = services.AccountUpdater(accountStore, cfg, existing.ID, other.Username)

--- a/app/services/credentials_verifier_test.go
+++ b/app/services/credentials_verifier_test.go
@@ -17,7 +17,7 @@ func TestCredentialsVerifierSuccess(t *testing.T) {
 
 	cfg := app.Config{BcryptCost: 4}
 	store := mock.NewAccountStore()
-	store.Create(username, bcrypted)
+	store.Create(services.User{Username: username, Password: bcrypted})
 
 	acc, err := services.CredentialsVerifier(store, &cfg, username, password)
 	require.NoError(t, err)
@@ -31,10 +31,10 @@ func TestCredentialsVerifierFailure(t *testing.T) {
 
 	cfg := app.Config{BcryptCost: 4}
 	store := mock.NewAccountStore()
-	store.Create("known", bcrypted)
-	acc, _ := store.Create("locked", bcrypted)
+	store.Create(services.User{Username: "known", Password: bcrypted})
+	acc, _ := store.Create(services.User{Username: "locked", Password: bcrypted})
 	store.Lock(acc.ID)
-	acc, _ = store.Create("expired", bcrypted)
+	acc, _ = store.Create(services.User{Username: "expired", Password: bcrypted})
 	store.RequireNewPassword(acc.ID)
 
 	testCases := []struct {

--- a/app/services/identity_reconciler.go
+++ b/app/services/identity_reconciler.go
@@ -4,9 +4,9 @@ import (
 	"encoding/hex"
 	"github.com/keratin/authn-server/app"
 	"github.com/keratin/authn-server/app/data"
+	"github.com/keratin/authn-server/app/models"
 	"github.com/keratin/authn-server/lib"
 	"github.com/keratin/authn-server/lib/oauth"
-	"github.com/keratin/authn-server/app/models"
 	"github.com/pkg/errors"
 	"golang.org/x/oauth2"
 )
@@ -58,7 +58,13 @@ func IdentityReconciler(accountStore data.AccountStore, cfg *app.Config, provide
 	}
 	// TODO: transactional account + identity
 	// Note we hex encode token because zxcvbn does not seem to like non-printable characters
-	newAccount, err := AccountCreator(accountStore, cfg, providerUser.Email, hex.EncodeToString(rand))
+	newAccount, err :=
+		AccountCreator(accountStore, cfg, User{
+			Username:   providerUser.Email,
+			Password:   []byte(hex.EncodeToString(rand)),
+			Name:       providerUser.Name,
+			PictureURL: providerUser.Picture,
+		})
 	if err != nil {
 		return nil, errors.Wrap(err, "AccountCreator")
 	}

--- a/app/services/identity_reconciler_test.go
+++ b/app/services/identity_reconciler_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/keratin/authn-server/lib/oauth"
 	"github.com/keratin/authn-server/app/services"
+	"github.com/keratin/authn-server/lib/oauth"
 	"golang.org/x/oauth2"
 
 	"github.com/keratin/authn-server/app"
@@ -19,21 +19,39 @@ func TestIdentityReconciler(t *testing.T) {
 	store := mock.NewAccountStore()
 	cfg := &app.Config{}
 
-	t.Run("linked account", func(t *testing.T) {
-		acct, err := store.Create("linked@test.com", []byte("password"))
+	t.Run("linked account should update name and pic if empty", func(t *testing.T) {
+		acct, err := store.Create(services.User{Username: "linked@test.com", Password: []byte("password")})
 		require.NoError(t, err)
 		err = store.AddOauthAccount(acct.ID, "testProvider", "123", "TOKEN")
 		require.NoError(t, err)
 
-		found, err := services.IdentityReconciler(store, cfg, "testProvider", &oauth.UserInfo{ID: "123", Email: "linked@test.com"}, &oauth2.Token{}, 0)
+		found, err := services.IdentityReconciler(store, cfg, "testProvider", &oauth.UserInfo{ID: "123", Email: "linked@test.com", Name: "New Name", Picture: "newPicture"}, &oauth2.Token{}, 0)
 		assert.NoError(t, err)
 		if assert.NotNil(t, found) {
-			assert.Equal(t, found.Username, "linked@test.com")
+			assert.Equal(t,  "linked@test.com", found.Username)
+			//assert.Equal(t, "New Name", found.Name)
+			//assert.Equal(t, "newPicture", found.PictureURL)
+
+		}
+	})
+
+	t.Run("linked account should maintain old name", func(t *testing.T) {
+		acct, err := store.Create(services.User{Username: "linkedWithName@test.com", Password: []byte("password"), Name: "Old Name", PictureURL: "oldPic"})
+		require.NoError(t, err)
+		err = store.AddOauthAccount(acct.ID, "testProvider", "555", "TOKEN")
+		require.NoError(t, err)
+
+		found, err := services.IdentityReconciler(store, cfg, "testProvider", &oauth.UserInfo{ID: "555", Email: "linkedWithName@test.com", Name: "New Name", Picture: "newPicture"}, &oauth2.Token{}, 0)
+		assert.NoError(t, err)
+		if assert.NotNil(t, found) {
+			assert.Equal(t, "linkedWithName@test.com", found.Username)
+			assert.Equal(t, "Old Name", found.Name)
+			assert.Equal(t, "oldPic", found.Picture)
 		}
 	})
 
 	t.Run("linked account that is locked", func(t *testing.T) {
-		acct, err := store.Create("linkedlocked@test.com", []byte("password"))
+		acct, err := store.Create(services.User{Username: "linkedlocked@test.com", Password: []byte("password")})
 		require.NoError(t, err)
 		err = store.AddOauthAccount(acct.ID, "testProvider", "234", "TOKEN")
 		require.NoError(t, err)
@@ -45,19 +63,34 @@ func TestIdentityReconciler(t *testing.T) {
 		assert.Nil(t, found)
 	})
 
-	t.Run("linkable account", func(t *testing.T) {
-		acct, err := store.Create("linkable@test.com", []byte("password"))
+	t.Run("linkable account updating name and pic", func(t *testing.T) {
+		acct, err := store.Create(services.User{Username: "linkable@test.com", Password: []byte("password")})
 		require.NoError(t, err)
 
-		found, err := services.IdentityReconciler(store, cfg, "testProvider", &oauth.UserInfo{ID: "345", Email: "linkable@test.com"}, &oauth2.Token{}, acct.ID)
+		found, err := services.IdentityReconciler(store, cfg, "testProvider", &oauth.UserInfo{ID: "345", Email: "linkable@test.com", Name: "New Name", Picture: "newPic"}, &oauth2.Token{}, acct.ID)
 		assert.NoError(t, err)
 		if assert.NotNil(t, found) {
-			assert.Equal(t, found.Username, "linkable@test.com")
+			assert.Equal(t, "linkable@test.com", found.Username)
+			//assert.Equal(t, "New Name", found.Name)
+			//assert.Equal(t, "newPic", found.PictureURL)
+		}
+	})
+
+	t.Run("linkable account maintains old name", func(t *testing.T) {
+		acct, err := store.Create(services.User{Username: "linkableWithName@test.com", Password: []byte("password"), Name: "Old Name", PictureURL: "oldPic"})
+		require.NoError(t, err)
+
+		found, err := services.IdentityReconciler(store, cfg, "testProvider", &oauth.UserInfo{ID: "666", Email: "linkableWithName@test.com", Name: "New Name", Picture: "newPic"}, &oauth2.Token{}, acct.ID)
+		assert.NoError(t, err)
+		if assert.NotNil(t, found) {
+			assert.Equal(t, "linkableWithName@test.com", found.Username)
+			assert.Equal(t, "Old Name", found.Name)
+			assert.Equal(t, "oldPic", found.Picture)
 		}
 	})
 
 	t.Run("linkable account that is linked", func(t *testing.T) {
-		acct, err := store.Create("linkablelinked@test.com", []byte("password"))
+		acct, err := store.Create(services.User{Username: "linkablelinked@test.com", Password: []byte("password")})
 		require.NoError(t, err)
 		err = store.AddOauthAccount(acct.ID, "testProvider", "0", "TOKEN")
 		require.NoError(t, err)
@@ -71,12 +104,12 @@ func TestIdentityReconciler(t *testing.T) {
 		found, err := services.IdentityReconciler(store, cfg, "testProvider", &oauth.UserInfo{ID: "567", Email: "new@test.com"}, &oauth2.Token{}, 0)
 		assert.NoError(t, err)
 		if assert.NotNil(t, found) {
-			assert.Equal(t, found.Username, "new@test.com")
+			assert.Equal(t, "new@test.com", found.Username)
 		}
 	})
 
 	t.Run("new account with username collision", func(t *testing.T) {
-		_, err := store.Create("existing@test.com", []byte("password"))
+		_, err := store.Create(services.User{Username: "existing@test.com", Password: []byte("password")})
 		require.NoError(t, err)
 
 		found, err := services.IdentityReconciler(store, cfg, "testProvider", &oauth.UserInfo{ID: "678", Email: "existing@test.com"}, &oauth2.Token{}, 0)

--- a/app/services/model.go
+++ b/app/services/model.go
@@ -1,0 +1,8 @@
+package services
+
+type User struct {
+	Username   string
+	Password   []byte
+	Name       string
+	PictureURL string
+}

--- a/app/services/password_changer_test.go
+++ b/app/services/password_changer_test.go
@@ -33,7 +33,7 @@ func TestPasswordChanger(t *testing.T) {
 			return nil, errors.Wrap(err, "bcrypt")
 		}
 
-		return accountStore.Create(username, hash)
+		return accountStore.Create(services.User{Username: username, Password: hash})
 	}
 
 	account, err := factory("existing@keratin.tech", "old")

--- a/app/services/password_expirer_test.go
+++ b/app/services/password_expirer_test.go
@@ -14,7 +14,7 @@ func TestPasswordExpirer(t *testing.T) {
 	refreshStore := mock.NewRefreshTokenStore()
 
 	t.Run("active account", func(t *testing.T) {
-		account, err := accountStore.Create("active", []byte("secret"))
+		account, err := accountStore.Create(services.User{Username: "active", Password: []byte("secret")})
 		require.NoError(t, err)
 		token1, err := refreshStore.Create(account.ID)
 		require.NoError(t, err)

--- a/app/services/password_resetter_test.go
+++ b/app/services/password_resetter_test.go
@@ -37,11 +37,11 @@ func TestPasswordResetter(t *testing.T) {
 		return err
 	}
 
-	account, err := accountStore.Create("existing@keratin.tech", []byte("old"))
+	account, err := accountStore.Create(services.User{Username: "existing@keratin.tech", Password: []byte("old")})
 	require.NoError(t, err)
 
 	t.Run("sets new password", func(t *testing.T) {
-		expired, err := accountStore.Create("expired@keratin.tech", []byte("old"))
+		expired, err := accountStore.Create(services.User{Username: "expired@keratin.tech", Password: []byte("old")})
 		require.NoError(t, err)
 		_, err = accountStore.RequireNewPassword(expired.ID)
 		require.NoError(t, err)
@@ -71,7 +71,7 @@ func TestPasswordResetter(t *testing.T) {
 	})
 
 	t.Run("on an archived account", func(t *testing.T) {
-		archived, err := accountStore.Create("archived@keratin.tech", []byte("old"))
+		archived, err := accountStore.Create(services.User{Username: "archived@keratin.tech", Password: []byte("old")})
 		require.NoError(t, err)
 		_, err = accountStore.Archive(archived.ID)
 		require.NoError(t, err)
@@ -83,7 +83,7 @@ func TestPasswordResetter(t *testing.T) {
 	})
 
 	t.Run("on a locked account", func(t *testing.T) {
-		locked, err := accountStore.Create("locked@keratin.tech", []byte("old"))
+		locked, err := accountStore.Create(services.User{Username: "locked@keratin.tech", Password: []byte("old")})
 		require.NoError(t, err)
 		_, err = accountStore.Lock(locked.ID)
 		require.NoError(t, err)

--- a/app/services/password_setter_test.go
+++ b/app/services/password_setter_test.go
@@ -23,7 +23,7 @@ func TestPasswordSetter(t *testing.T) {
 		return services.PasswordSetter(accountStore, &ops.LogReporter{logrus.New()}, cfg, id, password)
 	}
 
-	account, err := accountStore.Create("existing@keratin.tech", []byte("old"))
+	account, err := accountStore.Create(services.User{Username: "existing@keratin.tech", Password: []byte("old")})
 	require.NoError(t, err)
 
 	t.Run("sets password", func(t *testing.T) {

--- a/app/services/passwordless_token_verifier_test.go
+++ b/app/services/passwordless_token_verifier_test.go
@@ -44,7 +44,7 @@ func TestPasswordlessTokenVerifier(t *testing.T) {
 	})
 
 	t.Run("on an archived account", func(t *testing.T) {
-		archived, err := accountStore.Create("archived@keratin.tech", []byte("old"))
+		archived, err := accountStore.Create(services.User{Username: "archived@keratin.tech", Password: []byte("old")})
 		require.NoError(t, err)
 		_, err = accountStore.Archive(archived.ID)
 		require.NoError(t, err)
@@ -56,7 +56,7 @@ func TestPasswordlessTokenVerifier(t *testing.T) {
 	})
 
 	t.Run("on a locked account", func(t *testing.T) {
-		locked, err := accountStore.Create("locked@keratin.tech", []byte("old"))
+		locked, err := accountStore.Create(services.User{Username: "locked@keratin.tech", Password: []byte("old")})
 		require.NoError(t, err)
 		_, err = accountStore.Lock(locked.ID)
 		require.NoError(t, err)
@@ -68,7 +68,7 @@ func TestPasswordlessTokenVerifier(t *testing.T) {
 	})
 
 	t.Run("when account has logged in again", func(t *testing.T) {
-		account, err := accountStore.Create("account@keratin.tech", []byte("old"))
+		account, err := accountStore.Create(services.User{Username: "account@keratin.tech", Password: []byte("old")})
 		require.NoError(t, err)
 
 		token := newToken(account.ID)

--- a/app/services/session_creator_test.go
+++ b/app/services/session_creator_test.go
@@ -27,7 +27,7 @@ func TestSessionCreator(t *testing.T) {
 	reporter := &ops.LogReporter{logrus.New()}
 
 	audience := &route.Domain{"authn.example.com", "8080"}
-	account, err := accountStore.Create("existing", []byte("secret"))
+	account, err := accountStore.Create(services.User{Username: "existing", Password: []byte("secret")})
 	require.NoError(t, err)
 
 	t.Run("tracks last login while generating tokens", func(t *testing.T) {

--- a/docs/api.md
+++ b/docs/api.md
@@ -91,6 +91,8 @@ Visibility: Public
 | ------ | ---- | ----- |
 | `username` | string | Must be present and unique. |
 | `password` | string | Must meet minimum complexity scoring per [zxcvbn](https://blogs.dropbox.com/tech/2012/04/zxcvbn-realistic-password-strength-estimation/). |
+| `name` | string | User's complete name. |
+| `pictureURL` | string | A user's profile picture. |
 
 #### Success:
 
@@ -298,6 +300,8 @@ Visibility: Private
 | ------ | ---- | ----- |
 | `username` | string | Must exist and be unique, but otherwise not validated. |
 | `password` | string | May be either an existing BCrypt hash or a plaintext (raw) string. Will not be validated for complexity. |
+| `name` | string | The user's complete name |
+| `pictureURL` | string | A user's profile picture URL |
 | `locked` | boolean | Optional. Will import the account as [locked](#lock-account). |
 
 #### Success:

--- a/lib/oauth/discord.go
+++ b/lib/oauth/discord.go
@@ -35,8 +35,25 @@ func NewDiscordProvider(credentials *Credentials) *Provider {
 				return nil, err
 			}
 
-			var user UserInfo
-			err = json.Unmarshal(body, &user)
+			var dUser struct{
+				ID string `json:"id"`
+				Username string `json:"username"`
+				Email string `json:"email"`
+				AvatarHash string `json:"avatar"`
+			}
+
+			err = json.Unmarshal(body, &dUser)
+
+			user := UserInfo{
+				ID:      dUser.ID,
+				Email: dUser.Email,
+				Name: dUser.Username,
+				// avatar hash, need to check how to retrieve the proper link!?!
+				// Discord documentation:
+				// https://discordapp.com/developers/docs/resources/user#user-object
+				//
+				// PictureURL: "https://cdn.discordapp.com/avatars/" + dUser.ID + "/" + dUser.AvatarHash + ".png",
+			}
 			return &user, err
 		},
 	}

--- a/lib/oauth/github.go
+++ b/lib/oauth/github.go
@@ -3,11 +3,9 @@ package oauth
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
-	"strconv"
-
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/github"
+	"io/ioutil"
 )
 
 // NewGitHubProvider returns a AuthN integration for GitHub OAuth
@@ -19,74 +17,38 @@ func NewGitHubProvider(credentials *Credentials) *Provider {
 		Endpoint:     github.Endpoint,
 	}
 
-	getPrimaryEmail := func(t *oauth2.Token) (string, error) {
-		client := config.Client(context.TODO(), t)
-		resp, err := client.Get("https://api.github.com/user/emails")
-		if err != nil {
-			return "", err
-		}
-		defer resp.Body.Close()
-
-		body, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return "", err
-		}
-
-		var emails []struct {
-			Email   string
-			Primary bool
-		}
-		err = json.Unmarshal(body, &emails)
-		if err != nil {
-			return "", err
-		}
-		for _, email := range emails {
-			if email.Primary {
-				return email.Email, nil
-			}
-		}
-		return "", nil
-	}
-
-	getID := func(t *oauth2.Token) (string, error) {
-		client := config.Client(context.TODO(), t)
-		resp, err := client.Get("https://api.github.com/user")
-		if err != nil {
-			return "", err
-		}
-		defer resp.Body.Close()
-
-		body, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return "", err
-		}
-
-		var user struct {
-			ID int
-		}
-		err = json.Unmarshal(body, &user)
-		if err != nil {
-			return "", err
-		}
-		return strconv.Itoa(user.ID), nil
-	}
-
 	return &Provider{
 		config: config,
 		UserInfo: func(t *oauth2.Token) (*UserInfo, error) {
-			id, err := getID(t)
+			client := config.Client(context.TODO(), t)
+			resp, err := client.Get("https://api.github.com/user")
+			if err != nil {
+				return nil, err
+			}
+			defer resp.Body.Close()
+
+			body, err := ioutil.ReadAll(resp.Body)
 			if err != nil {
 				return nil, err
 			}
 
-			email, err := getPrimaryEmail(t)
+			var user struct {
+				ID     string `json:"id"`
+				Name   string `json:"name"`
+				Email  string `json:"email"`
+				Avatar string `json:"avatar_url"`
+			}
+
+			err = json.Unmarshal(body, &user)
 			if err != nil {
 				return nil, err
 			}
 
 			return &UserInfo{
-				ID:    id,
-				Email: email,
+				ID:      user.ID,
+				Email:   user.Email,
+				Name:    user.Name,
+				Picture: user.Avatar,
 			}, nil
 		},
 	}

--- a/lib/oauth/google.go
+++ b/lib/oauth/google.go
@@ -14,7 +14,7 @@ func NewGoogleProvider(credentials *Credentials) *Provider {
 	config := &oauth2.Config{
 		ClientID:     credentials.ID,
 		ClientSecret: credentials.Secret,
-		Scopes:       []string{"email"},
+		Scopes:       []string{"email", "profile"},
 		Endpoint:     google.Endpoint,
 	}
 
@@ -34,6 +34,7 @@ func NewGoogleProvider(credentials *Credentials) *Provider {
 			}
 
 			var user UserInfo
+
 			err = json.Unmarshal(body, &user)
 			return &user, err
 		},

--- a/lib/oauth/provider.go
+++ b/lib/oauth/provider.go
@@ -14,6 +14,9 @@ type Provider struct {
 type UserInfo struct {
 	ID    string `json:"id"`
 	Email string `json:"email"`
+	Name  string `json:"name"`
+	// picture field could possibly be empty
+	Picture string `json:"picture"`
 }
 
 // UserInfoFetcher is the function signature for fetching UserInfo from a Provider

--- a/lib/oauth/test.go
+++ b/lib/oauth/test.go
@@ -20,8 +20,10 @@ func NewTestProvider(s *httptest.Server) *Provider {
 		// The test implementation returns a fake user with an email address copied from the supplied access token.
 		func(t *oauth2.Token) (*UserInfo, error) {
 			return &UserInfo{
-				ID:    t.AccessToken,
-				Email: t.AccessToken,
+				ID:      t.AccessToken,
+				Email:   t.AccessToken,
+				Name:    t.AccessToken,
+				Picture: t.AccessToken,
 			}, nil
 		},
 	}

--- a/server/handlers/delete_account_test.go
+++ b/server/handlers/delete_account_test.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/keratin/authn-server/server/test"
 	"github.com/keratin/authn-server/lib/route"
+	"github.com/keratin/authn-server/server/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -25,7 +25,7 @@ func TestDeleteAccount(t *testing.T) {
 	})
 
 	t.Run("unarchived account", func(t *testing.T) {
-		account, err := app.AccountStore.Create("unlocked@test.com", []byte("bar"))
+		account, err := app.AccountStore.Create(test.User{Username: "unlocked@test.com", Password: []byte("bar")})
 		require.NoError(t, err)
 
 		res, err := client.Delete(fmt.Sprintf("/accounts/%v", account.ID))
@@ -38,7 +38,7 @@ func TestDeleteAccount(t *testing.T) {
 	})
 
 	t.Run("archived account", func(t *testing.T) {
-		account, err := app.AccountStore.Create("locked@test.com", []byte("bar"))
+		account, err := app.AccountStore.Create(test.User{Username: "locked@test.com", Password: []byte("bar")})
 		require.NoError(t, err)
 		app.AccountStore.Archive(account.ID)
 

--- a/server/handlers/get_account.go
+++ b/server/handlers/get_account.go
@@ -30,6 +30,8 @@ func GetAccount(app *app.App) http.HandlerFunc {
 		WriteData(w, http.StatusOK, map[string]interface{}{
 			"id":       account.ID,
 			"username": account.Username,
+			"name":		account.Name,
+			"picture":  account.Picture,
 			"locked":   account.Locked,
 			"deleted":  account.DeletedAt != nil,
 		})

--- a/server/handlers/get_account_test.go
+++ b/server/handlers/get_account_test.go
@@ -5,9 +5,9 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/keratin/authn-server/server/test"
-	"github.com/keratin/authn-server/lib/route"
 	"github.com/keratin/authn-server/app/models"
+	"github.com/keratin/authn-server/lib/route"
+	"github.com/keratin/authn-server/server/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -32,7 +32,7 @@ func TestGetAccount(t *testing.T) {
 	})
 
 	t.Run("valid account", func(t *testing.T) {
-		account, err := app.AccountStore.Create("unlocked@test.com", []byte("bar"))
+		account, err := app.AccountStore.Create(test.User{Username: "unlocked@test.com", Password: []byte("bar"), Name: "Some Dude", PictureURL: "http://pic.com"})
 		require.NoError(t, err)
 
 		res, err := client.Get(fmt.Sprintf("/accounts/%v", account.ID))
@@ -48,6 +48,8 @@ func assertGetAccountResponse(t *testing.T, res *http.Response, acc *models.Acco
 	responseData := struct {
 		ID       int    `json:"id"`
 		Username string `json:"username"`
+		Name     string `json:"name"`
+		Picture  string `json:"picture"`
 		Locked   bool   `json:"locked"`
 		Deleted  bool   `json:"deleted_at"`
 	}{}
@@ -56,6 +58,8 @@ func assertGetAccountResponse(t *testing.T, res *http.Response, acc *models.Acco
 
 	assert.Equal(t, acc.Username, responseData.Username)
 	assert.Equal(t, acc.ID, responseData.ID)
+	assert.Equal(t, acc.Name, responseData.Name)
+	assert.Equal(t, acc.Picture, responseData.Picture)
 	assert.Equal(t, false, responseData.Locked)
 	assert.Equal(t, false, responseData.Deleted)
 }

--- a/server/handlers/get_accounts_available_test.go
+++ b/server/handlers/get_accounts_available_test.go
@@ -15,7 +15,7 @@ func TestGetAccountsAvailable(t *testing.T) {
 	server := test.Server(app)
 	defer server.Close()
 
-	account, err := app.AccountStore.Create("existing@test.com", []byte("bar"))
+	account, err := app.AccountStore.Create(test.User{Username: "existing@test.com", Password: []byte("bar")})
 	require.NoError(t, err)
 
 	client := route.NewClient(server.URL).Referred(&app.Config.ApplicationDomains[0])

--- a/server/handlers/get_oauth_return_test.go
+++ b/server/handlers/get_oauth_return_test.go
@@ -9,10 +9,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/keratin/authn-server/server/test"
+	oauthtoken "github.com/keratin/authn-server/app/tokens/oauth"
 	oauthlib "github.com/keratin/authn-server/lib/oauth"
 	"github.com/keratin/authn-server/lib/route"
-	oauthtoken "github.com/keratin/authn-server/app/tokens/oauth"
+	"github.com/keratin/authn-server/server/test"
 )
 
 func TestGetOauthReturn(t *testing.T) {
@@ -60,7 +60,7 @@ func TestGetOauthReturn(t *testing.T) {
 	})
 
 	t.Run("connect new identity with current session", func(t *testing.T) {
-		account, err := app.AccountStore.Create("existing@keratin.tech", []byte("password"))
+		account, err := app.AccountStore.Create(test.User{Username: "existing@keratin.tech", Password: []byte("password")})
 		require.NoError(t, err)
 		session := test.CreateSession(app.RefreshTokenStore, app.Config, account.ID)
 
@@ -72,7 +72,7 @@ func TestGetOauthReturn(t *testing.T) {
 	})
 
 	t.Run("not connect new identity with current session that is already linked", func(t *testing.T) {
-		account, err := app.AccountStore.Create("linked@keratin.tech", []byte("password"))
+		account, err := app.AccountStore.Create(test.User{Username: "linked@keratin.tech", Password: []byte("password")})
 		require.NoError(t, err)
 		app.AccountStore.AddOauthAccount(account.ID, "test", "PREVIOUSID", "TOKEN")
 		session := test.CreateSession(app.RefreshTokenStore, app.Config, account.ID)
@@ -83,7 +83,7 @@ func TestGetOauthReturn(t *testing.T) {
 	})
 
 	t.Run("log in to existing identity", func(t *testing.T) {
-		account, err := app.AccountStore.Create("registered@keratin.tech", []byte("password"))
+		account, err := app.AccountStore.Create(test.User{Username: "registered@keratin.tech", Password: []byte("password")})
 		require.NoError(t, err)
 		err = app.AccountStore.AddOauthAccount(account.ID, "test", "REGISTEREDID", "TOKEN")
 		require.NoError(t, err)
@@ -98,7 +98,7 @@ func TestGetOauthReturn(t *testing.T) {
 	})
 
 	t.Run("log in to locked identity", func(t *testing.T) {
-		account, err := app.AccountStore.Create("locked@keratin.tech", []byte("password"))
+		account, err := app.AccountStore.Create(test.User{Username: "locked@keratin.tech", Password: []byte("password")})
 		require.NoError(t, err)
 		_, err = app.AccountStore.Lock(account.ID)
 		require.NoError(t, err)
@@ -109,7 +109,7 @@ func TestGetOauthReturn(t *testing.T) {
 	})
 
 	t.Run("email collision", func(t *testing.T) {
-		_, err := app.AccountStore.Create("collision@keratin.tech", []byte("password"))
+		_, err := app.AccountStore.Create(test.User{Username: "collision@keratin.tech", Password: []byte("password")})
 		require.NoError(t, err)
 
 		res, err := client.Get("/oauth/test/return?code=collision@keratin.tech&state=" + state)

--- a/server/handlers/get_password_reset_test.go
+++ b/server/handlers/get_password_reset_test.go
@@ -18,7 +18,7 @@ func TestGetPasswordReset(t *testing.T) {
 	client := route.NewClient(server.URL).Referred(&app.Config.ApplicationDomains[0])
 
 	t.Run("known account", func(t *testing.T) {
-		_, err := app.AccountStore.Create("known@keratin.tech", []byte("pwd"))
+		_, err := app.AccountStore.Create(test.User{Username: "known@keratin.tech", Password: []byte("pwd")})
 		require.NoError(t, err)
 
 		res, err := client.Get("/password/reset?username=known@keratin.tech")

--- a/server/handlers/get_session_token_test.go
+++ b/server/handlers/get_session_token_test.go
@@ -18,7 +18,7 @@ func TestGetSessionToken(t *testing.T) {
 	client := route.NewClient(server.URL).Referred(&app.Config.ApplicationDomains[0])
 
 	t.Run("known account", func(t *testing.T) {
-		_, err := app.AccountStore.Create("known@keratin.tech", []byte("pwd"))
+		_, err := app.AccountStore.Create(test.User{Username: "known@keratin.tech", Password: []byte("pwd")})
 		require.NoError(t, err)
 
 		res, err := client.Get("/session/token?username=known@keratin.tech")

--- a/server/handlers/patch_account_expire_password_test.go
+++ b/server/handlers/patch_account_expire_password_test.go
@@ -26,7 +26,7 @@ func TestPatchAccountExpirePassword(t *testing.T) {
 	})
 
 	t.Run("active account", func(t *testing.T) {
-		account, err := app.AccountStore.Create("active@test.com", []byte("bar"))
+		account, err := app.AccountStore.Create(test.User{Username: "active@test.com", Password: []byte("bar")})
 		require.NoError(t, err)
 
 		res, err := client.Patch(fmt.Sprintf("/accounts/%v/expire_password", account.ID), url.Values{})

--- a/server/handlers/patch_account_lock_test.go
+++ b/server/handlers/patch_account_lock_test.go
@@ -26,7 +26,7 @@ func TestPatchAccountLock(t *testing.T) {
 	})
 
 	t.Run("unlocked account", func(t *testing.T) {
-		account, err := app.AccountStore.Create("unlocked@test.com", []byte("bar"))
+		account, err := app.AccountStore.Create(test.User{Username: "unlocked@test.com", Password: []byte("bar")})
 		require.NoError(t, err)
 
 		res, err := client.Patch(fmt.Sprintf("/accounts/%v/lock", account.ID), url.Values{})
@@ -39,7 +39,7 @@ func TestPatchAccountLock(t *testing.T) {
 	})
 
 	t.Run("locked account", func(t *testing.T) {
-		account, err := app.AccountStore.Create("locked@test.com", []byte("bar"))
+		account, err := app.AccountStore.Create(test.User{Username: "locked@test.com", Password: []byte("bar")})
 		require.NoError(t, err)
 		app.AccountStore.Lock(account.ID)
 

--- a/server/handlers/patch_account_test.go
+++ b/server/handlers/patch_account_test.go
@@ -28,7 +28,7 @@ func TestPatchAccount(t *testing.T) {
 	})
 
 	t.Run("existing account", func(t *testing.T) {
-		account, err := app.AccountStore.Create("one@test.com", []byte("bar"))
+		account, err := app.AccountStore.Create(test.User{Username: "one@test.com", Password: []byte("bar")})
 		require.NoError(t, err)
 
 		res, err := client.Patch(fmt.Sprintf("/accounts/%v", account.ID), url.Values{"username": []string{"newname"}})
@@ -41,7 +41,7 @@ func TestPatchAccount(t *testing.T) {
 	})
 
 	t.Run("existing account using JSON", func(t *testing.T) {
-		account, err := app.AccountStore.Create("two@test.com", []byte("bar"))
+		account, err := app.AccountStore.Create(test.User{Username: "two@test.com", Password: []byte("bar")})
 		require.NoError(t, err)
 
 		res, err := client.PatchJSON(fmt.Sprintf("/accounts/%v", account.ID), "{\"username\": \"secondUsername\"}")
@@ -54,7 +54,7 @@ func TestPatchAccount(t *testing.T) {
 	})
 
 	t.Run("bad username", func(t *testing.T) {
-		account, err := app.AccountStore.Create("three@test.com", []byte("bar"))
+		account, err := app.AccountStore.Create(test.User{Username: "three@test.com", Password: []byte("bar")})
 		require.NoError(t, err)
 
 		res, err := client.Patch(fmt.Sprintf("/accounts/%v", account.ID), url.Values{"username": []string{""}})

--- a/server/handlers/patch_account_unlock_test.go
+++ b/server/handlers/patch_account_unlock_test.go
@@ -26,7 +26,7 @@ func TestPatchAccountUnlock(t *testing.T) {
 	})
 
 	t.Run("unlocked account", func(t *testing.T) {
-		account, err := app.AccountStore.Create("unlocked@test.com", []byte("bar"))
+		account, err := app.AccountStore.Create(test.User{Username: "unlocked@test.com", Password: []byte("bar")})
 		require.NoError(t, err)
 
 		res, err := client.Patch(fmt.Sprintf("/accounts/%v/unlock", account.ID), url.Values{})
@@ -39,7 +39,7 @@ func TestPatchAccountUnlock(t *testing.T) {
 	})
 
 	t.Run("locked account", func(t *testing.T) {
-		account, err := app.AccountStore.Create("locked@test.com", []byte("bar"))
+		account, err := app.AccountStore.Create(test.User{Username: "locked@test.com", Password: []byte("bar")})
 		require.NoError(t, err)
 		app.AccountStore.Lock(account.ID)
 

--- a/server/handlers/post_account.go
+++ b/server/handlers/post_account.go
@@ -4,17 +4,19 @@ import (
 	"github.com/keratin/authn-server/lib/parse"
 	"net/http"
 
-	"github.com/keratin/authn-server/server/sessions"
 	"github.com/keratin/authn-server/app"
-	"github.com/keratin/authn-server/lib/route"
 	"github.com/keratin/authn-server/app/services"
+	"github.com/keratin/authn-server/lib/route"
+	"github.com/keratin/authn-server/server/sessions"
 )
 
 func PostAccount(app *app.App) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var credentials struct {
-			Username string
-			Password string
+			Username   string
+			Password   string
+			Name       string
+			PictureURL string
 		}
 		if err := parse.Payload(r, &credentials); err != nil {
 			WriteErrors(w, err)
@@ -23,10 +25,12 @@ func PostAccount(app *app.App) http.HandlerFunc {
 		// Create the account
 		account, err := services.AccountCreator(
 			app.AccountStore,
-			app.Config,
-			credentials.Username,
-			credentials.Password,
-		)
+			app.Config, services.User{
+				Username:   credentials.Username,
+				Password:   []byte(credentials.Password),
+				Name:       credentials.Name,
+				PictureURL: credentials.PictureURL,
+			})
 		if err != nil {
 			if fe, ok := err.(services.FieldErrors); ok {
 				WriteErrors(w, fe)

--- a/server/handlers/post_account_test.go
+++ b/server/handlers/post_account_test.go
@@ -21,6 +21,8 @@ func TestPostAccountSuccess(t *testing.T) {
 	res, err := client.PostForm("/accounts", url.Values{
 		"username": []string{"foo"},
 		"password": []string{"0a0b0c0"},
+		"name": []string{"A name"},
+		"pictureURL": []string{"http://picture.url"},
 	})
 	require.NoError(t, err)
 

--- a/server/handlers/post_accounts_import.go
+++ b/server/handlers/post_accounts_import.go
@@ -12,9 +12,11 @@ import (
 func PostAccountsImport(app *app.App) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var user struct {
-			Username string
-			Password string
-			Locked string
+			Username   string
+			Password   string
+			Name       string
+			PictureURL string
+			Locked     string
 		}
 		if err := parse.Payload(r, &user); err != nil {
 			WriteErrors(w, err)
@@ -28,8 +30,12 @@ func PostAccountsImport(app *app.App) http.HandlerFunc {
 		account, err := services.AccountImporter(
 			app.AccountStore,
 			app.Config,
-			user.Username,
-			user.Password,
+			services.User{
+				Username:   user.Username,
+				Password:   []byte(user.Password),
+				Name:       user.Name,
+				PictureURL: user.PictureURL,
+			},
 			locked,
 		)
 		if err != nil {
@@ -41,8 +47,10 @@ func PostAccountsImport(app *app.App) http.HandlerFunc {
 			panic(err)
 		}
 
-		WriteData(w, http.StatusCreated, map[string]int{
-			"id": account.ID,
+		WriteData(w, http.StatusCreated, map[string]interface{}{
+			"id":      account.ID,
+			"name":    account.Name,
+			"picture": account.Picture,
 		})
 	}
 }

--- a/server/handlers/post_accounts_import_test.go
+++ b/server/handlers/post_accounts_import_test.go
@@ -23,13 +23,15 @@ func TestPostAccountsImport(t *testing.T) {
 		res, err := client.PostForm("/accounts/import", url.Values{
 			"username": []string{"someone@app.com"},
 			"password": []string{"secret"},
+			"name":		[]string{"A Name"},
+			"pictureURL":  []string{"http://picture.com"},
 		})
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusCreated, res.StatusCode)
 
 		account, err := app.AccountStore.FindByUsername("someone@app.com")
 		require.NoError(t, err)
-		test.AssertData(t, res, map[string]int{"id": account.ID})
+		test.AssertData(t, res, map[string]interface{}{"id": account.ID, "name": "A Name", "picture": "http://picture.com"})
 	})
 
 	t.Run("importing a locked user", func(t *testing.T) {

--- a/server/handlers/post_password.go
+++ b/server/handlers/post_password.go
@@ -4,17 +4,17 @@ import (
 	"github.com/keratin/authn-server/lib/parse"
 	"net/http"
 
-	"github.com/keratin/authn-server/server/sessions"
 	"github.com/keratin/authn-server/app"
-	"github.com/keratin/authn-server/lib/route"
 	"github.com/keratin/authn-server/app/services"
+	"github.com/keratin/authn-server/lib/route"
+	"github.com/keratin/authn-server/server/sessions"
 )
 
 func PostPassword(app *app.App) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var credentials struct {
-			Token string
-			Password string
+			Token           string
+			Password        string
 			CurrentPassword string
 		}
 		if err := parse.Payload(r, &credentials); err != nil {

--- a/server/handlers/post_password_test.go
+++ b/server/handlers/post_password_test.go
@@ -40,7 +40,7 @@ func TestPostPassword(t *testing.T) {
 			return nil, errors.Wrap(err, "bcrypt")
 		}
 
-		return app.AccountStore.Create(username, hash)
+		return app.AccountStore.Create(test.User{Username: username, Password: hash})
 	}
 
 	t.Run("valid reset token", func(t *testing.T) {

--- a/server/handlers/post_session_test.go
+++ b/server/handlers/post_session_test.go
@@ -20,7 +20,7 @@ func TestPostSessionSuccess(t *testing.T) {
 	defer server.Close()
 
 	b, _ := bcrypt.GenerateFromPassword([]byte("bar"), 4)
-	app.AccountStore.Create("foo", b)
+	app.AccountStore.Create(test.User{Username: "foo", Password: b})
 
 	client := route.NewClient(server.URL).Referred(&app.Config.ApplicationDomains[0])
 	res, err := client.PostForm("/session", url.Values{
@@ -40,7 +40,7 @@ func TestPostSessionSuccessWithSession(t *testing.T) {
 	defer server.Close()
 
 	b, _ := bcrypt.GenerateFromPassword([]byte("bar"), 4)
-	app.AccountStore.Create("foo", b)
+	app.AccountStore.Create(test.User{Username: "foo", Password: b})
 
 	accountID := 8642
 	session := test.CreateSession(app.RefreshTokenStore, app.Config, accountID)

--- a/server/handlers/post_session_token_test.go
+++ b/server/handlers/post_session_token_test.go
@@ -40,7 +40,7 @@ func TestPostSessionToken(t *testing.T) {
 			return nil, errors.Wrap(err, "bcrypt")
 		}
 
-		return app.AccountStore.Create(username, hash)
+		return app.AccountStore.Create(test.User{Username: username, Password: hash})
 	}
 
 	t.Run("valid passwordless token", func(t *testing.T) {

--- a/server/test/model.go
+++ b/server/test/model.go
@@ -1,0 +1,8 @@
+package test
+
+type User struct {
+	Username   string
+	Password   []byte
+	Name       string
+	PictureURL string
+}


### PR DESCRIPTION
### What

-  Retrieve Name and Avatar from Oauth Providers so that when logging in using this method, we have this information already in the user identity.
-  Create safe constructors for account_store implementations

### Why

Authn-server is an identity and authentication provider. As so, it makes sense that at least name and picture (a nice to have, I admit it) are part of an account.
Another reasoning behind this is that it is easier to fetch this info here on AuthN server then trying to fetch this information later from another service. Otherwise another service would need to have access to the JWT token from any of these OAuth providers and effectively know a lot about how to retrieve this info just to fetch it if desired, while Authn already has this knowledge and this access token
### How

Add name and picture to Create and Patch methods, while also creating the necessary migrations.
TO DO still in this PR:

-  Live-test against all OAuth providers if the implementation for fetching the user info is actually working (implementation for DIscord is missing picture, didn't quite get how to fetch the avatar)
-  Improve Patch method to allow updating name and picture
